### PR TITLE
Fix rspec 1x type error

### DIFF
--- a/lib/sauce/integrations.rb
+++ b/lib/sauce/integrations.rb
@@ -111,7 +111,7 @@ begin
       end
     end
   end
-rescue LoadError
+rescue LoadError, TypeError
   # User doesn't have RSpec 2.x installed
 end
 


### PR DESCRIPTION
Fix TypeError that SeleniumExampleGroup is not a module when RSpec 1.x is loaded but not RSpec 2.x
