### PR TITLE
Fix to allow running outside a rails app using rspec 1.x

### DIFF
--- a/lib/sauce/integrations.rb
+++ b/lib/sauce/integrations.rb
@@ -19,8 +19,10 @@ begin
               @@tunnel = Sauce::Connect.new(:host => config.application_host, :port => config.application_port || 80)
               @@tunnel.wait_until_ready
             end
-            @@server = Sauce::Utilities::RailsServer.new
-            @@server.start
+            if File.exists?('script/rails') # or some other canonical way to detect if rails?
+              @@server = Sauce::Utilities::RailsServer.new
+              @@server.start
+            end
           end
         end
 


### PR DESCRIPTION
I had to fork and tweak the begin block for rspec 1.x, adding some logic to prevent the RailsApp from starting up.  I saw elsewhere in the code, looking for 'script/server' was used to see if it was within a rails app (although this wouldn't necessarily work for rails 3.x).  But regardless, I think the behavior should be to only try to start the rails app if it's within one.  It appears this is the case with rspec 2.x
