### PR TITLE
Removed deprecated method

### DIFF
--- a/lib/sauce/integrations.rb
+++ b/lib/sauce/integrations.rb
@@ -113,7 +113,7 @@ begin
           need_tunnel = false
           config = Sauce::Config.new
           files_to_run = ::Rspec.configuration.respond_to?(:files_to_run) ? ::Rspec.configuration.files_to_run :
-            ::RSpec.configuration.settings[:files_to_run]
+            ::RSpec.configuration.files_to_run
           if config.application_host && !config.local?
             need_tunnel = files_to_run.any? {|file| file =~ /spec\/selenium\//}
           end


### PR DESCRIPTION
I tried to run the test to make sure that I haven't broken anything, but the test is broken. I ran the test without making any changes and it was indeed broken. I'm presently looking into how I might fix the test. However, I can confirm that the change I have made enables the sauce gem to work with rspec-core >= v2.8.
