### PR TITLE
Add an Around hook for Cucumber users to integrate with the Jenkins Sauce OnDemand plugin

### DIFF
--- a/lib/sauce/capybara.rb
+++ b/lib/sauce/capybara.rb
@@ -53,8 +53,39 @@ end
 
 # Switch Cucumber stories tagged with @selenium to use sauce
 begin
-  Before("@selenium") do
+  Before('@selenium') do
     Capybara.current_driver = :sauce
   end
+
+  Around('@selenium') do |scenario, block|
+    # If we're running under Jenkins, we should dump the
+    # `SauceOnDemandSessionID` into the Console Output for the Sauce OnDemand
+    # Jenkins plugin.
+    # See: <https://github.com/saucelabs/sauce_ruby/issues/48>
+    Capybara.current_driver = :sauce
+    driver = Capybara.current_session.driver
+    scenario_name = scenario.name.split("\n").first
+    feature_name = scenario.feature.short_name
+
+    # JENKINS_SERVER_COOKIE seems to be as good as any sentinel value to
+    # determine whether we're running under Jenkins or not.
+    if ENV['JENKINS_SERVER_COOKIE']
+      output = []
+      output << "\nSauceOnDemandSessionID=#{driver.browser.session_id}"
+      # The duplication in the scenario_name comes from the fact that the
+      # JUnit formatter seems to do the same, so in order to get the sauce
+      # OnDemand plugin for Jenkins to co-operate, we need to double it up as
+      # well
+      output << "job-name=#{feature_name}.#{scenario_name}.#{scenario_name}"
+      puts output.join(' ')
+    end
+
+    block.call
+
+    # Quit the driver to allow for the generation of a new session_id
+    driver.browser.quit
+    driver.instance_variable_set(:@browser, nil)
+  end
+
 rescue NoMethodError
 end


### PR DESCRIPTION
Unfortunately this doesn't come with any tests, I will have to ponder on a good
mechanism for testing cucumber hooks at a later date, when I'm smarter.

Depends (effectively) on [this pull request to cucumber](https://github.com/cucumber/cucumber/pull/259)
