### PR TITLE
Bug fix: blocks should be routed through #handle_retry in Capybara drive...

### DIFF
--- a/lib/sauce/capybara.rb
+++ b/lib/sauce/capybara.rb
@@ -25,7 +25,7 @@ module Sauce
                   ::Selenium::WebDriver::Error::UnknownError]
       MAX_RETRIES = 3
 
-      def handle_retry(method, *args)
+      def handle_retry(method, *args, &block)
         retries = 0
 
         # Disable retries only when we really really want to, this will remain
@@ -35,7 +35,7 @@ module Sauce
         end
 
         begin
-          send("base_#{method}".to_sym, *args)
+          send("base_#{method}".to_sym, *args, &block)
         rescue *RETRY_ON => e
           if retries < MAX_RETRIES
             puts "Received an exception (#{e}), retrying"
@@ -62,8 +62,8 @@ module Sauce
       [:find, :visit, :current_url, :reset!, :within_frame,
        :within_window, :find_window, :body, :source,
        :execute_script, :evaluate_script].each do |method|
-        define_method(method) do |*args|
-          handle_retry(method, *args)
+        define_method(method) do |*args, &block|
+          handle_retry(method, *args, &block)
         end
       end
 

--- a/spec/sauce/capybara_spec.rb
+++ b/spec/sauce/capybara_spec.rb
@@ -127,6 +127,15 @@ describe Sauce::Capybara do
       end
     end
 
+    describe '#within_frame' do
+      it 'should route through #handle_retry and yield block' do
+        driver.should_receive(:base_within_frame).and_yield
+        driver.within_frame do
+          "lol"
+        end
+      end
+    end
+
   end
 
   describe '#install_hooks' do


### PR DESCRIPTION
Fixes a bug I was experiencing when using Capybara #within_frame with a block. The block would not be routed through handle_return and a LocalJumpError was raised when trying to yield.
