### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/examples/helper.rb
+++ b/examples/helper.rb
@@ -5,12 +5,12 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'sauce'
 
 Sauce.config do |config|
-  config.browsers = [
+  config[:browsers] = [
     ["Linux", "firefox", "3.6."],
     #["Windows 2003", "safariproxy", "5."]
   ]
-  config.browser_url = "http://saucelabs.com"
+  config[:browser_url] = "http://saucelabs.com"
 
-  #config.application_host = "localhost"
-  #config.application_port = "4444"
+  #config[:application_host] = "localhost"
+  #config[:application_port] = "4444"
 end

--- a/examples/rails3-demo/test/test_helper.rb
+++ b/examples/rails3-demo/test/test_helper.rb
@@ -15,10 +15,10 @@ end
 require 'sauce'
 
 Sauce.config do |conf|
-    conf.browsers = [
+    conf[:browsers] = [
         ["Windows 2003", "firefox", "3.6."]
     ]
-    conf.application_host = "127.0.0.1"
-    conf.application_port = "3001"
-    conf.browser_url = "http://localhost:3001/"
+    conf[:application_host] = "127.0.0.1"
+    conf[:application_port] = "3001"
+    conf[:browser_url] = "http://localhost:3001/"
 end

--- a/generators/sauce/sauce_generator.rb
+++ b/generators/sauce/sauce_generator.rb
@@ -37,12 +37,12 @@ class SauceGenerator < Rails::Generator::Base
 require 'sauce'
 
 Sauce.config do |conf|
-    conf.browser_url = "http://#{rand(100000)}.test/"
-    conf.browsers = [
+    conf[:browser_url] = "http://#{rand(100000)}.test/"
+    conf[:browsers] = [
         ["Windows 2003", "firefox", "3.6."]
     ]
-    conf.application_host = "127.0.0.1"
-    conf.application_port = "3001"
+    conf[:application_host] = "127.0.0.1"
+    conf[:application_port] = "3001"
 end
         CONFIG
       end

--- a/lib/generators/sauce/install/install_generator.rb
+++ b/lib/generators/sauce/install/install_generator.rb
@@ -40,12 +40,12 @@ module Sauce
 require 'sauce'
 
 Sauce.config do |conf|
-    conf.browsers = [
+    conf[:browsers] = [
         ["Windows 2003", "firefox", "3.6."]
     ]
-    conf.application_host = "127.0.0.1"
-    conf.application_port = "3001"
-    conf.browser_url = "http://localhost:3001/"
+    conf[:application_host] = "127.0.0.1"
+    conf[:application_port] = "3001"
+    conf[:browser_url] = "http://localhost:3001/"
 end
           CONFIG
       end

--- a/lib/sauce/integrations.rb
+++ b/lib/sauce/integrations.rb
@@ -17,7 +17,7 @@ begin
         before :suite do
           config = Sauce::Config.new
           if @@need_tunnel
-            if config.application_host
+            if config[:application_host]
               @@tunnel = Sauce::Connect.new(:host => config.application_host, :port => config.application_port || 80)
               @@tunnel.connect
               @@tunnel.wait_until_ready
@@ -37,7 +37,7 @@ begin
         def execute(*args)
           config = Sauce::Config.new
           description = [self.class.description, self.description].join(" ")
-          config.browsers.each do |os, browser, version|
+          config[:browsers].each do |os, browser, version|
             @selenium = Sauce::Selenium2.new({:os => os, :browser => browser,
                                               :browser_version => version,
                                               :job_name => description})
@@ -94,7 +94,7 @@ begin
           config = Sauce::Config.new
           files_to_run = ::RSpec.configuration.respond_to?(:files_to_run) ? ::RSpec.configuration.files_to_run :
             ::RSpec.configuration.settings[:files_to_run]
-          if config.application_host
+          if config[:application_host]
             need_tunnel = files_to_run.any? {|file| file =~ /spec\/selenium\//}
           end
           if need_tunnel
@@ -138,7 +138,7 @@ module Sauce
       end
       unless my_name =~ /^default_test/
         config = Sauce::Config.new
-        if config.application_host
+        if config[:application_host]
           unless ENV['TEST_ENV_NUMBER'].to_i > 1
             Sauce::Connect.ensure_connected(:host => config.application_host, :port => config.application_port || 80)
           end
@@ -156,7 +156,7 @@ module Sauce
           end
         end
 
-        config.browsers.each do |os, browser, version|
+        config[:browsers].each do |os, browser, version|
           options = self.class.sauce_config
           options.merge!({:os => os, :browser => browser,
                           :browser_version => version,

--- a/spec/sauce/config_spec.rb
+++ b/spec/sauce/config_spec.rb
@@ -57,11 +57,11 @@ describe Sauce::Config do
   describe '#os' do
     it 'should return the value set in the config block' do
       Sauce.config do |config|
-        config.os = 'TEST_OS'
+        config[:os] = 'TEST_OS'
       end
 
       c = Sauce::Config.new
-      c.os.should == 'TEST_OS'
+      c[:os].should == 'TEST_OS'
     end
   end
 
@@ -206,7 +206,7 @@ describe Sauce::Config do
     describe 'browsers=' do
       it 'should default the config to the first item' do
         Sauce.config do |config|
-          config.browsers = [['TEST_OS', 'TEST_BROWSER', 'TEST_BROWSER_VERSION']]
+          config[:browsers] = [['TEST_OS', 'TEST_BROWSER', 'TEST_BROWSER_VERSION']]
         end
 
         c = Sauce::Config.new
@@ -228,7 +228,7 @@ describe Sauce::Config do
 
     it 'should allow overrides as constructor options' do
       Sauce.config do |config|
-        config.browsers = [['OS1', 'BROWSER1', 'BROWSER_VERSION1']]
+        config[:browsers] = [['OS1', 'BROWSER1', 'BROWSER_VERSION1']]
       end
 
       c = Sauce::Config.new(:os => 'OS2', :browser => 'BROWSER2',


### PR DESCRIPTION
Fix places that caused warnings like:
[DEPRECATED] This method (browsers=) is deprecated, please use the [] and []= accessors instead.

Test suite passes only with less warnings.
