### PR TITLE
Capybara should use the same driver as the one started by test unit

### DIFF
--- a/lib/sauce/integrations.rb
+++ b/lib/sauce/integrations.rb
@@ -182,8 +182,10 @@ module Sauce
                           :browser_version => version,
                           :job_name => my_name.to_s})
           @browser = Sauce::Selenium2.new(options)
+          Sauce.driver_pool[Thread.current.object_id] = @browser
           super(*args, &blk)
           @browser.stop
+          Sauce.driver_pool.delete Thread.current.object_id
         end
       end
     end


### PR DESCRIPTION
I tried to recreate a test similar to 
https://github.com/sauce-labs/sauce_ruby/blob/master/spec/integration/rspec/spec/selenium/selenium_with_capybara_spec.rb#L28

But noticed that when I ran this spec file locally , it's failing on master branch itself
