### PR TITLE
Allow to not run local application

### DIFF
--- a/lib/sauce/config.rb
+++ b/lib/sauce/config.rb
@@ -29,7 +29,7 @@ module Sauce
         :local_application_port => "3001",
         :capture_traffic => false,
         :start_tunnel => true,
-        :start_local_application => false
+        :start_local_application => true
     }
 
     ENVIRONMENT_VARIABLES = %w{SAUCE_HOST SAUCE_PORT SAUCE_BROWSER_URL SAUCE_USERNAME

--- a/lib/sauce/integrations.rb
+++ b/lib/sauce/integrations.rb
@@ -18,7 +18,7 @@ begin
           config = Sauce::Config.new
           if @@need_tunnel
             if config[:application_host]
-              @@tunnel = Sauce::Connect.new(:host => config.application_host, :port => config.application_port || 80)
+              @@tunnel = Sauce::Connect.new(:host => config[:application_host], :port => config[:application_port] || 80)
               @@tunnel.connect
               @@tunnel.wait_until_ready
             end
@@ -99,7 +99,7 @@ begin
 
           config = Sauce::Config.new
           if config[:application_host]
-            @@tunnel ||= Sauce::Connect.new(:host => config.application_host, :port => config.application_port || 80)
+            @@tunnel ||= Sauce::Connect.new(:host => config[:application_host], :port => config[:application_port] || 80)
             @@tunnel.connect
             @@tunnel.wait_until_ready
           end
@@ -120,7 +120,7 @@ begin
             need_tunnel = files_to_run.any? {|file| file =~ /spec\/selenium\//}
           end
           if need_tunnel
-            @@tunnel ||= Sauce::Connect.new(:host => config.application_host, :port => config.application_port || 80)
+            @@tunnel ||= Sauce::Connect.new(:host => config[:application_host], :port => config[:application_port] || 80)
             @@tunnel.connect
             @@tunnel.wait_until_ready
           end
@@ -163,7 +163,7 @@ module Sauce
         config = Sauce::Config.new
         if config[:application_host]
           unless ENV['TEST_ENV_NUMBER'].to_i > 1
-            Sauce::Connect.ensure_connected(:host => config.application_host, :port => config.application_port || 80)
+            Sauce::Connect.ensure_connected(:host => config[:application_host], :port => config[:application_port] || 80)
           end
         end
 


### PR DESCRIPTION
Add `start_local_application` config key to disable the Rails server automated start
