### PR TITLE
Make timeout configurable

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -11,6 +11,7 @@ module Sauce
       @status = "uninitialized"
       @error = nil
       @quiet = options[:quiet]
+      @timeout = options.fetch(:timeout) { TIMEOUT }
       @config = Sauce::Config.new(options)
 
       if @config.username.nil?
@@ -70,7 +71,7 @@ module Sauce
 
     def wait_until_ready
       start = Time.now
-      while !@ready and (Time.now-start) < TIMEOUT and @error != "Missing requirements"
+      while !@ready and (Time.now-start) < @timeout and @error != "Missing requirements"
         sleep 0.5
       end
 
@@ -79,7 +80,7 @@ module Sauce
       end
 
       if !@ready
-        raise "Sauce Connect failed to connect after #{TIMEOUT} seconds"
+        raise "Sauce Connect failed to connect after #{@timeout} seconds"
       end
     end
 


### PR DESCRIPTION
We ran into a problem where the 90 seconds sometimes wasn't enough time to open the connection from our machines. We fixed this problem by reassigning the `TIMEOUT`-constant which is of course not ideal. 

Therefore I added a configuration parameter that allows you to change the default timeout.

Sadly I didn't find a place to integrate tests for this if you give me a pointer I can still add them. However the code is pretty straight forward and so tests may not be needed at all. 
