### PR TITLE
Move parallel_test to 0.16.6

### DIFF
--- a/sauce.gemspec
+++ b/sauce.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.add_dependency('json', [">= 1.2.0"])
   s.add_dependency('cmdparse', [">= 2.0.2"])
   s.add_dependency('highline', [">= 1.5.0"])
-  s.add_dependency('parallel_tests', ["= 0.16.5"])
+  s.add_dependency('parallel_tests', ["= 0.16.6"])
   s.add_dependency('sauce_whisk', ["~> 0.0.8"])
 end


### PR DESCRIPTION
Update the gemspec for Sauce Ruby, to include parallel_test version 0.16.6.
