### PR TITLE
Fix name of :files argument

### DIFF
--- a/lib/tasks/parallel_testing.rb
+++ b/lib/tasks/parallel_testing.rb
@@ -5,7 +5,7 @@ require "parallel_tests/cli_patch"
 
 
 namespace :sauce do
-  task :spec, :spec_files, :concurrency, :test_options, :parallel_options do |t, args|
+  task :spec, :files, :concurrency, :test_options, :parallel_options do |t, args|
     ::RSpec::Core::Runner.disable_autorun!
     parallel_arguments = parse_task_args(:rspec, args)
     ParallelTests::CLI.new.run(parallel_arguments)
@@ -90,7 +90,7 @@ def parse_task_args(test_tool=:rspec, args)
 
   concurrency = args[:concurrency] || env_args[:concurrency] || default[:concurrency]
   test_options = args[:test_options] || env_args[:test_options] || default[:test_options]
-  parallel_options = args[:parallel_options] || env_args[:parallel_options] 
+  parallel_options = args[:parallel_options] || env_args[:parallel_options]
   files = args[:files] || env_args[:files] || default[:files]
 
   return_args = [
@@ -98,9 +98,9 @@ def parse_task_args(test_tool=:rspec, args)
     '--type'
   ]
 
-  return_args.push 'saucerspec' if test_tool == :rspec 
+  return_args.push 'saucerspec' if test_tool == :rspec
   return_args.push 'saucecucumber' if test_tool == :cucumber
-    
+
   if test_options
     return_args.push '-o'
     return_args.push test_options


### PR DESCRIPTION
RSpec task was taking in :spec_files but the parser was looking for :files. Used the latter to allow for consistency with Cucumber task.
