### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -174,11 +174,11 @@ You can pass arguments to these tasks to control concurrency, specs/features to 
 
 ```
 # Run login\spec across all platforms with up to 8 concurrent specs
-$ bundle exec sauce:spec concurrency=8 specs="spec/login_spec.rb"
+$ bundle exec rake sauce:spec concurrency=8 test_files="spec/login_spec.rb"
 
 
 # Run report.feature across all platforms with up to 3 concurrent features
-$ bundle exec sauce:features concurrency=3 features="features/report.feature"
+$ bundle exec rake sauce:features concurrency=3 features="features/report.feature"
 ```
 
 Check out the [Parallisation guide](https://github.com/sauce-labs/sauce_ruby/wiki/Concurrent-Testing) for more details.


### PR DESCRIPTION
cbb1ba5897e422732f8b855d92ba0f78f890e893 changed env var from 'specs' to 'test_files'. The  README wasn't updated to reflect this. This commit updates the docs
