### PR TITLE
Capybara needs to be a dev dependency

### DIFF
--- a/gemfiles/capybara-2.0.x.gemfile
+++ b/gemfiles/capybara-2.0.x.gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => "../"
 
 gem 'rake'
-gem 'capybara', "~> 2.0.0"
+gem 'capybara', "~> 2.2.1"
 
 group :test do
   gem 'cucumber'

--- a/sauce.gemspec
+++ b/sauce.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("rspec", ["~> 2.14.0"])
   s.add_development_dependency("simplecov")
-  s.add_dependency("capybara", [">= 2.2.1"])
+  s.add_development_dependency("capybara", [">= 2.2.1"])
   s.add_dependency('net-http-persistent')
   s.add_dependency('rest-client', [">= 0"])
   s.add_dependency('net-ssh', [">= 0"])


### PR DESCRIPTION
@mrloop Just FYI, Capybara is an optional integration so we don't make it a hard dependency.  We use gemfiles/whatever to get Travis to check our different versions of Capybara, so version dependencies go in there.
