### PR TITLE
Allow Browsers to be a single array

### DIFF
--- a/lib/sauce/config.rb
+++ b/lib/sauce/config.rb
@@ -105,6 +105,9 @@ module Sauce
     end
 
     def []=(key, value)
+      if(key == :browsers)
+        value = [value] unless value.first.instance_of?(Array)
+      end
       @undefaulted_opts.merge!({key => value})
       @opts[key] = value
     end


### PR DESCRIPTION
Allow the user to specify a single array to the config, rather than an array of arrays

Currently you need to do something like:

``` ruby
Sauce.config do |c|
  c[:browsers] = [
    ["Windows 8", "Internet Explorer", "10"]
  ]
end
```

With this change you can do:

``` ruby
Sauce.config do |c|
  c[:browsers] = ["Windows 8", "Internet Explorer", "10"]
end
```

Also, since there is logic in the setter, I've changed `method_missing` to call it, rather than accessing `@opts` directly.
