### PR TITLE
Made Capybara work with standalone rake apps.

### DIFF
--- a/spec/integration/connect/Gemfile
+++ b/spec/integration/connect/Gemfile
@@ -4,3 +4,4 @@ gem "rake"
 gem "rspec"
 gem 'sauce', :path => '../../../'
 gem 'sauce-connect', :path => '../../../gems/sauce-connect'
+gem 'capybara'

--- a/spec/integration/connect/spec/spec_helper.rb
+++ b/spec/integration/connect/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require "sauce"
-require "sauce/connect"
+require "capybara/rspec"
+require "sauce/capybara"
 
 Sauce.config do |c|
   c[:start_tunnel] = true
+  c[:warn_on_skipped_integration] = false
 end

--- a/spec/sauce/capybara_spec.rb
+++ b/spec/sauce/capybara_spec.rb
@@ -293,4 +293,31 @@ describe Sauce::Capybara do
 
   describe '#install_hooks' do
   end
+
+  describe 'Standalone' do
+    include Capybara::DSL
+    before :all do
+      app = proc { |env| [200, {}, ["Hello Sauce!"]]}
+      Capybara.app = app
+
+      @existing_run_server = Capybara.run_server
+      Capybara.configure do |config|
+        config.run_server = true
+      end
+      Capybara.javascript_driver = :sauce
+
+      Sauce.driver_pool[Thread.current.object_id] = nil
+    end
+
+    after :all do
+      Capybara.configure do |config|
+        config.run_server = @existing_run_server
+      end
+    end
+
+    it "should use one of the Sauce Connect ports", :js => true do
+      used_port = Capybara.current_session.server.port
+      Sauce::Config::POTENTIAL_PORTS.should include used_port 
+    end
+  end
 end


### PR DESCRIPTION
Default Capybara to using a Sauce Connect port.

Moved Capybara configuration logic into the Sauce::Capybara module, then
called it from sauce/capybara (delicious testing).

Set Capybara.always_include_port to true for local Rack applications.

Added Capybara to connect integration gemfile.
