### PR TITLE
Do not set Capybara.app_host if it is not nil (already set)

### DIFF
--- a/lib/sauce/capybara.rb
+++ b/lib/sauce/capybara.rb
@@ -136,9 +136,11 @@ begin
       module SeleniumExampleGroup
         ::RSpec.configuration.before(:suite, :sauce => true) do
           ::Capybara.configure do |config|
-            host = Sauce::Config.new[:application_host] || "127.0.0.1"
-            port = Sauce::Config.new[:application_port]
-            config.app_host = "http://#{host}:#{port}"
+            if config.app_host.nil?
+              host = Sauce::Config.new[:application_host] || "127.0.0.1"
+              port = Sauce::Config.new[:application_port]
+              config.app_host = "http://#{host}:#{port}"
+            end
             config.run_server = false
           end
         end


### PR DESCRIPTION
Prevent overriding of Capybara.app_host by sauce gem, if it was already set (e.g. in spec_helper.rb, while configuring Capybara default options). Capybara.app_host need to be defined on a global scope in order to easily swap between different capybara drivers (:sauce, :chrome, etc)
