### PR TITLE
Fixed malformed json string.

### DIFF
--- a/lib/sauce/parallel/test_broker.rb
+++ b/lib/sauce/parallel/test_broker.rb
@@ -28,7 +28,7 @@ module Sauce
           browsers[file] << test_groups[file].next_platform
         end
 
-        return {:SAUCE_PERFILE_BROWSERS => "'" + JSON.generate(browsers) + "'"}
+        return {:SAUCE_PERFILE_BROWSERS => "#{JSON.generate(browsers)}"}
       end
     end
 


### PR DESCRIPTION
This fix addressed an error on Windows where the json generated for SAUCE_PERFILE_BROWSERS was incorrect and caused test execution to fail.
