### PR TITLE
Add railtie to fix missing rake tasks problem

### DIFF
--- a/lib/sauce.rb
+++ b/lib/sauce.rb
@@ -1,15 +1,20 @@
-require 'sauce/version'
-require 'sauce/utilities'
-require 'sauce/utilities/rake'
-require 'sauce/job'
-require 'sauce/client'
-require 'sauce/config'
-require 'sauce/selenium'
-require 'sauce/rspec'
-require 'sauce/test_unit'
-require 'tasks/parallel_testing'
-require 'parallel_tests/saucerspec/runner'
-require 'parallel_tests/saucecucumber/runner'
+if defined?(Rails)
+  require "sauce/railtie"
+else
+  require 'sauce/version'
+  require 'sauce/utilities'
+  require 'sauce/utilities/rake'
+  require 'sauce/job'
+  require 'sauce/client'
+  require 'sauce/config'
+  require 'sauce/selenium'
+  require 'sauce/rspec'
+  require 'sauce/test_unit'
+  require 'tasks/parallel_testing'
+  require 'parallel_tests/saucerspec/runner'
+  require 'parallel_tests/saucecucumber/runner'
+end
+
 
 # Ruby before 1.9.3-p382 does not handle exit codes correctly when nested
 if RUBY_VERSION == "1.9.3" && RUBY_PATCHLEVEL < 392

--- a/lib/sauce/railtie.rb
+++ b/lib/sauce/railtie.rb
@@ -1,0 +1,20 @@
+require 'sauce'
+require 'rails'
+module Sauce
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      require 'sauce/version'
+      require 'sauce/utilities'
+      require 'sauce/utilities/rake'
+      require 'sauce/job'
+      require 'sauce/client'
+      require 'sauce/config'
+      require 'sauce/selenium'
+      require 'sauce/rspec'
+      require 'sauce/test_unit'
+      require 'tasks/parallel_testing'
+      require 'parallel_tests/saucerspec/runner'
+      require 'parallel_tests/saucecucumber/runner'
+    end
+  end
+end


### PR DESCRIPTION
Added a railtie to include rake tasks after bundle.

Fix for issue described in https://github.com/saucelabs/sauce_ruby/issues/217
