### PR TITLE
Don't rely on LoadErrors in Parallel::TestBroker#load_sauce_config

### DIFF
--- a/lib/sauce/parallel/test_broker.rb
+++ b/lib/sauce/parallel/test_broker.rb
@@ -6,6 +6,7 @@ require "thread"
 
 module Sauce
   class TestBroker
+    POSSIBLE_CONFIGURATION_FILES = ["./spec/sauce_helper.rb", "./spec/spec_helper.rb", "./features/support/sauce_helper.rb"]
 
     def self.reset
       if defined? @@platforms
@@ -74,25 +75,14 @@ module Sauce
     end
 
     def self.load_sauce_config
-      begin
-        if File.exists? "./spec/sauce_helper.rb"
-          require "./spec/sauce_helper"
-        else
-          require "./spec/spec_helper"
-        end
-      rescue LoadError => e
-        # Gross, but maybe theyre using Cuke
-        begin
-          if File.exists? "./features/support/sauce_helper.rb"
-            require "./features/support/sauce_helper"
-          else
-            raise LoadError "Can't find sauce_helper, please add it in ./features/support/sauce_helper.rb"
-          end
-        rescue LoadError => e
-          #WHO KNOWS
-        end
+      configuration_file = POSSIBLE_CONFIGURATION_FILES.find { |file_path| File.exists?(file_path) }
+      if configuration_file
+        require configuration_file
+      else
+        error_message = "Could not find Sauce configuration. Please make sure one of the following files exists:\n"
+        error_message << POSSIBLE_CONFIGURATION_FILES.map { |file_path| "  - #{file_path}" }.join("\n")
+        raise error_message
       end
-
     end
 
     SAUCE_USERNAME = ENV["SAUCE_USERNAME"]


### PR DESCRIPTION
The load_sauce_config method in lib/sauce/parallel/test_broker.rb is more complicated than it needs to be and doesn't even work. The following line doesn't do what it is supposed to:

```
raise LoadError "Can't find sauce_helper, please add it in ./features/support/sauce_helper.rb"
```

It raises a NoMethodError since LoadError is not a method. The error it was supposed to raise would have been misleading anyway. That is the error that is supposed to be raised when none of the config files exist. It doesn't mean you need a ./features/support/sauce_helper.rb file.

I believe this simplifies the code and is closer to the behavior a user would want.
