### PR TITLE
Add iedriver-version to configurable sauce options (SAUCE_OPTIONS).

### DIFF
--- a/lib/sauce/config.rb
+++ b/lib/sauce/config.rb
@@ -67,7 +67,7 @@ module Sauce
         sauce-advisor single-window user-extensions-url firefox-profile-url
         max-duration idle-timeout build custom-data tunnel-identifier
         selenium-version command-timeout prerun prerun-args screen-resolution
-        disable-popup-handler avoid-proxy public name}
+        disable-popup-handler avoid-proxy public name iedriver-version}
 
     def self.get_application_port
       port_index = ENV["TEST_ENV_NUMBER"].to_i

--- a/spec/sauce/config/config_spec.rb
+++ b/spec/sauce/config/config_spec.rb
@@ -201,6 +201,14 @@ describe Sauce::Config do
 
         it { should have_key :'prerun'}
       end
+
+      context 'iedriver-version' do
+        subject do
+          Sauce::Config.new('iedriver-version' => '2.30.1').to_desired_capabilities
+        end
+
+        it { should have_key :'iedriver-version' }
+      end
     end
 
     context 'with a :name set' do


### PR DESCRIPTION
Seems like the right place to add iedriver-version to the desired capabilities.
