### PR TITLE
Be smarter about searching for config files for Cucumber or RSpec

### DIFF
--- a/lib/parallel_tests/saucecucumber/runner.rb
+++ b/lib/parallel_tests/saucecucumber/runner.rb
@@ -19,11 +19,9 @@ module ParallelTests
         execute_command(cmd, process_number, num_processes, options)
       end
 
-
-
       def self.tests_in_groups(tests, num_groups, options={})
         originals = (options[:group_by] == :steps) ? Grouper.by_steps(find_tests(tests, options), num_groups, options) : super
-        all_tests = originals.flatten * Sauce::TestBroker.test_platforms.length
+        all_tests = originals.flatten * Sauce::TestBroker.test_platforms(:cucumber).length
         base_group_size = all_tests.length / num_groups
         num_full_groups = all_tests.length - (base_group_size * num_groups)
 

--- a/lib/parallel_tests/saucerspec/runner.rb
+++ b/lib/parallel_tests/saucerspec/runner.rb
@@ -18,7 +18,7 @@ module ParallelTests
 
 
       def self.tests_in_groups(tests, num_groups, options={})
-        all_tests = super.flatten * Sauce::TestBroker.test_platforms.length
+        all_tests = super.flatten * Sauce::TestBroker.test_platforms(:rspec).length
         base_group_size = all_tests.length / num_groups
         num_full_groups = all_tests.length - (base_group_size * num_groups)
 


### PR DESCRIPTION
Prefer the config file locations for the tool being used, when running one of the parallel rake tasks.

This avoids the `does not have method 'length'` issue.
