### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/sauce/config.rb
+++ b/lib/sauce/config.rb
@@ -347,7 +347,7 @@ module Sauce
         ]
 
         paths.each do |path|
-            if File.exists? path
+            if File.exist? path
                 conf = YAML.load_file(path)
                 return conf.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
             end


### PR DESCRIPTION
`File.exists?` is deprecated according to
http://batsov.com/articles/2014/02/05/a-list-of-deprecated-stuff-in-ruby/

We should use `File.exist?` instead.

Without this fix, using Ruby 2.1.2 and sauce 3.4.9, I'm constantly getting warnings (like 100 warnings per spec) as follows:

```
/cache/bundle-install/ruby/2.1.0/gems/sauce-3.4.9/lib/sauce/config.rb:350: warning: File.exists? is a deprecated name, use File.exist? instead
/cache/bundle-install/ruby/2.1.0/gems/sauce-3.4.9/lib/sauce/config.rb:350: warning: File.exists? is a deprecated name, use File.exist? instead
<repeat>
```
