### PR TITLE
have option to pass in sauce connect timeout from config

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -16,8 +16,8 @@ module Sauce
       @status = "uninitialized"
       @error = nil
       @quiet = options[:quiet]
-      @timeout = options.fetch(:timeout) { TIMEOUT }
       @config = Sauce::Config.new(options)
+      @timeout = @config[:sauce_connect_timeout] || TIMEOUT
       @skip_connection_test = @config[:skip_connection_test]
 
       if @config.username.nil?


### PR DESCRIPTION
Previously I saw no way to pass in the sauce connect timeout when using the rspec setup. Hopefully this will make setting the timeout a little more accessible. 

You can set the timeout in your Sauce.config, or you can pass the timeout as an arg for those who start a sauce-connect manually.

#Usage:
```
Sauce.config do |config|
  config[:sauce_connect_timeout] = 120
end
```

or

```
Sauce::Connect.new({:sauce_connect_timeout => 120})
```

This will break the existing code if anyone was starting a sauce connect using `Sauce::Connect.new({:timeout => 100})`. I didn't want to name the key `:timeout` as it will not be clear what the `:timeout` key does in the `Sauce.config`

Would like some feedback on this. Thanks