### PR TITLE
Missing comma in connect.rb

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -41,7 +41,7 @@ module Sauce
 
       unless response.kind_of? Net::HTTPOK
         $stderr.puts Sauce::Connect.cant_access_rest_api_message
-        raise TunnelNotPossibleException "Couldn't access REST API"
+        raise TunnelNotPossibleException, "Couldn't access REST API"
       end
 
       begin


### PR DESCRIPTION
You'll see an error like this:

```
Failure/Error: Unable to find matching line from backtrace
    NoMethodError:
      undefined method `TunnelNotPossibleException' for #<Sauce::Connect:0x007f8d219ba6d0>
```