### PR TITLE
Nullifying Sauce.driver_pool

### DIFF
--- a/lib/sauce/capybara.rb
+++ b/lib/sauce/capybara.rb
@@ -106,6 +106,7 @@ module Sauce
       def finish!
         @browser.quit if existing_browser?
         @browser = nil
+        Sauce.driver_pool[Thread.current.object_id] = nil
       end
 
       def render(path)


### PR DESCRIPTION
Need to nullify this as well otherwise rspec_browser returns an object which can't be used because it's pointing at the  closed session. This happens when you run background tasks in cucumber. Previous scenario closes the browser, and in your background you try to interact with a page, it tries to use old browser and thorws exception.