### PR TITLE
Require 'forwardable' for extending Sauce::Selenium2

### DIFF
--- a/lib/sauce/selenium.rb
+++ b/lib/sauce/selenium.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 require "sauce/driver_pool"
 
 require "selenium/client"


### PR DESCRIPTION
Solves the issue whereby, on certain environments, an RSpec example group using Sauce may fail with `uninitialized constant Sauce::Selenium2::Forwardable (NameError)`. As is the case for example on [this Travis job](https://travis-ci.org/biril/backbone-control/jobs/50558552).

