### PR TITLE
Fix Sauce Connect ready regex

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -97,7 +97,7 @@ module Sauce
             if line =~ /Tunnel remote VM is (.*) (\.\.|at)/
               @status = $1
             end
-            if line =~/You may start your tests\./
+            if line =~/You may start your tests\./i
               @ready = true
             end
             if line =~ /- (Problem.*)$/


### PR DESCRIPTION
When using Sauce Connect 4, the successfully connected message is "Sauce Connect is up, you may start your tests", and on the old version it was "You may start your tests", so this case insensitive regex should solve it for both.