### PR TITLE
Be more modern

### DIFF
--- a/examples/rails3-demo/test/test_helper.rb
+++ b/examples/rails3-demo/test/test_helper.rb
@@ -21,4 +21,16 @@ Sauce.config do |conf|
     conf[:application_host] = "127.0.0.1"
     conf[:application_port] = "3001"
     conf[:browser_url] = "http://localhost:3001/"
+    conf[:sauce_connect_4_executable] = ENV["SAUCE_CONNECT_4_EXECUTABLE"]
+end
+
+require 'sauce'
+
+Sauce.config do |conf|
+    conf[:browsers] = [
+        ["Windows 2003", "firefox", "3.6."]
+    ]
+    conf[:application_host] = "127.0.0.1"
+    conf[:application_port] = "3001"
+    conf[:browser_url] = "http://localhost:3001/"
 end

--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -43,7 +43,7 @@ module Sauce
 
       unless response.kind_of? Net::HTTPOK
         $stderr.puts Sauce::Connect.cant_access_rest_api_message
-        raise TunnelNotPossibleException "Couldn't access REST API"
+        raise TunnelNotPossibleException, "Couldn't access REST API"
       end
 
       begin
@@ -184,10 +184,10 @@ module Sauce
         if File.executable? absolute_path
           true
         else
-          raise TunnelNotPossibleException "#{absolute_path} is not executable by #{Process.euid}"
+          raise TunnelNotPossibleException, "#{absolute_path} is not executable by #{Process.euid}"
         end
       else
-        raise TunnelNotPossibleException "#{absolute_path} does not exist"
+        raise TunnelNotPossibleException, "#{absolute_path} does not exist"
       end
     end
 

--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -138,7 +138,9 @@ module Sauce
       end
 
       if !@ready
-        raise "Sauce Connect failed to connect after #{@timeout} seconds"
+        error_message = "Sauce Connect failed to connect after #{@timeout} seconds"
+        error_message << "\n(Using Sauce Connect at #{@sc4_executable}" if @sc4_executable
+        raise error_message
       end
     end
 

--- a/lib/sauce/rspec/rspec_formatter.rb
+++ b/lib/sauce/rspec/rspec_formatter.rb
@@ -15,4 +15,6 @@ begin
   end
 rescue LoadError
   # User isn't using RSpec
+rescue NameError
+  # User is using RSpec 3
 end

--- a/lib/sauce/rspec/rspec_one_support.rb
+++ b/lib/sauce/rspec/rspec_one_support.rb
@@ -64,22 +64,3 @@ rescue => e
   STDERR.puts "Exception occured: #{e.to_s}"
   exit 1
 end
-
-begin
-  require 'rspec/core/formatters/base_text_formatter'
-  module RSpec
-    module Core
-      module Formatters
-        class BaseTextFormatter
-          def dump_failure(example, index)
-            output.puts "#{short_padding}#{index.next}) #{example.full_description}"
-            puts "#{short_padding}Sauce public job link: #{example.metadata[:sauce_public_link]}"
-            dump_failure_info(example)
-          end
-        end
-      end
-    end
-  end
-rescue LoadError
-  # User isn't using RSpec
-end

--- a/sauce.gemspec
+++ b/sauce.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |s|
   s.add_dependency('json', [">= 1.2.0"])
   s.add_dependency('cmdparse', [">= 2.0.2"])
   s.add_dependency('highline', [">= 1.5.0"])
-  s.add_dependency('parallel_tests', ["= 1.0.6"])
+  s.add_dependency('parallel_tests', [">= 1.1.1", "<= 1.3.7"])
   s.add_dependency('sauce_whisk', ["~> 0.0.11"])
 end

--- a/spec/integration/connect/spec/spec_helper.rb
+++ b/spec/integration/connect/spec/spec_helper.rb
@@ -14,6 +14,8 @@ require "sauce/capybara"
 Sauce.config do |c|
   c[:start_tunnel] = true
   c[:warn_on_skipped_integration] = false
+  c[:sauce_connect_4_executable] = ENV["SAUCE_CONNECT_4_EXECUTABLE"]
  end
-      app = proc { |env| [200, {}, ["Hello Sauce!"]]}
-      Capybara.app = app
+
+app = proc { |env| [200, {}, ["Hello Sauce!"]]}
+Capybara.app = app

--- a/spec/integration/rspec-capybara/spec/spec_helper.rb
+++ b/spec/integration/rspec-capybara/spec/spec_helper.rb
@@ -25,6 +25,7 @@ Sauce.config do |c|
       ["Windows 2008", "iexplore", "9"]
   ]
 
+  c[:sauce_connect_4_executable] = ENV["SAUCE_CONNECT_4_EXECUTABLE"]
   c[:application_host] = "localhost"
 end
 

--- a/spec/integration/rspec/run-test.sh
+++ b/spec/integration/rspec/run-test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash --login
-RAKE="bundle exec rake"
+rvm current
 
-bundle install
+RAKE="bundle exec rake"
+bundle update
 
 ${RAKE} spec

--- a/spec/integration/rspec/spec/spec_helper.rb
+++ b/spec/integration/rspec/spec/spec_helper.rb
@@ -46,3 +46,7 @@ shared_examples_for "an integrated spec" do
     $TAGGED_EXECUTIONS += 1
   end
 end
+
+Sauce.config do |c|
+  c[:sauce_connect_4_executable] = ENV["SAUCE_CONNECT_4_EXECUTABLE"]
+end

--- a/spec/integration/testunit/test/integration_test.rb
+++ b/spec/integration/testunit/test/integration_test.rb
@@ -4,6 +4,7 @@ Sauce.config do |c|
   c[:browsers] = [
       ["Windows 7", "Firefox", "18"]
   ]
+  c[:sauce_connect_4_executable] = ENV["SAUCE_CONNECT_4_EXECUTABLE"]
 end
 
 class IntegrationTest < Sauce::TestCase


### PR DESCRIPTION
Updating Parallel tests to 1.3.7
Avoiding inclusion of formatter when using RSpec 3 because it's broken
Removing formatters for RSpec 1
Updating all tests to use SC 4
Added output for SC4 executable path when errors occur