### PR TITLE
Sauce::Connect#command_prefix needs to return the command prefix

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -172,9 +172,8 @@ module Sauce
     # SC4 doesn't require a prefix
     def command_prefix
       unless @sc4_executable
-        "java -jar "
+        return "java -jar "
       end
-
       ""
     end
 


### PR DESCRIPTION
Sauce::Connect#command_prefix needs to actually return the command prefix in the case where @sc4_executable is not set.