### PR TITLE
Remove SC3 entirely.

### DIFF
--- a/gems/sauce-connect/changelog.markdown
+++ b/gems/sauce-connect/changelog.markdown
@@ -1,20 +1,28 @@
-# 3.5.3
+# 3.6
+## 3.6.0
+Removed SC3 functionality entirely.
+
+# 3.5
+## 3.5.3
 Include comma when throwing exception.  Thanks @hawknewton!
 
-# 3.5.2
+## 3.5.2
 Modify the successful start regex to be case insensitive.  Thanks @Ricardonacif!
 
-# 3.5.1
+## 3.5.1
 Allow for the `sauce_connect_4_executable` config value, allowing a SC 4 executable downloaded separately to be run.
 
-# 3.2.2
+# 3.2
+## 3.2.2
 Check if the Sauce Connect servers are accessible before connecting
 
-# 3.1.0
+# 3.1
+## 3.1.0
 Reset Step status to ensure Features run as often as requested, not just once
 
-# 3.0.2
+# 3.0
+## 3.0.2
 Re-push to resolve missing sauce-connect.rz
 
-# 3.0.1
+## 3.0.1
 Allowed passing of commandline arguments (Thanks, Rick Martínez!)

--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -29,6 +29,10 @@ module Sauce
       if @config.access_key.nil?
         raise ArgumentError, "Access key required to launch Sauce Connect. Please set the environment variable $SAUCE_ACCESS_KEY"
       end
+
+      if @config.sauce_connect_4_executable.nil?
+        raise TunnelNotPossibleException, Sauce::Connect.plzGetSC4
+      end
     end
 
     def ensure_connection_is_possible
@@ -54,7 +58,6 @@ module Sauce
         $stderr.puts Sauce::Connect.port_not_open_message
         raise TunnelNotPossibleException, "Couldn't use port 443"
       end
-
     end
 
     def connect
@@ -62,63 +65,54 @@ module Sauce
         ensure_connection_is_possible
       end
 
-      if java_is_present?
-        puts "[Sauce Connect is connecting to Sauce Labs...]"
+      puts "[Sauce Connect is connecting to Sauce Labs...]"
 
-        formatted_cli_options = array_of_formatted_cli_options_from_hash(cli_options)
+      formatted_cli_options = array_of_formatted_cli_options_from_hash(cli_options)
 
-        command_args = []
-        if @sc4_executable
-          command_args = ['-u', @config.username, '-k', @config.access_key]
-        else
-          command_args = [@config.username, @config.access_key]
-        end
+      command_args = ['-u', @config.username, '-k', @config.access_key]
+      command_args << formatted_cli_options
+      
+      command = "exec #{find_sauce_connect} #{command_args.join(' ')} 2>&1"
 
-        command_args << formatted_cli_options
-        command = "exec #{connect_command} #{command_args.join(' ')} 2>&1"
-
-        unless @quiet
-          string_arguments = formatted_cli_options.join(' ')
-          puts "[Sauce Connect arguments: '#{string_arguments}' ]"
-        end
-
-        @pipe = IO.popen(command)
-
-        @process_status = $?
-        at_exit do
-          Process.kill("INT", @pipe.pid)
-          while @ready
-            sleep 1
-          end
-        end
-
-        Thread.new {
-          while( (line = @pipe.gets) )
-            if line =~ /Tunnel remote VM is (.*) (\.\.|at)/
-              @status = $1
-            end
-            if line =~/You may start your tests\./i
-              @ready = true
-            end
-            if line =~ /- (Problem.*)$/
-              @error = $1
-              @quiet = false
-            end
-            if line =~ /== Missing requirements ==/
-              @error = "Missing requirements"
-              @quiet = false
-            end
-            if line =~/Invalid API_KEY provided/
-              @error = "Invalid API_KEY provided"
-              @quiet = false
-            end
-            $stderr.puts line unless @quiet
-          end
-          @ready = false
-        }
-      else
-        raise "Java doesn't seem to be installed.  Sauce Connect requires a working install of Java to proceed."
+      unless @quiet
+        string_arguments = formatted_cli_options.join(' ')
+        puts "[Sauce Connect arguments: '#{string_arguments}' ]"
       end
+
+      @pipe = IO.popen(command)
+
+      @process_status = $?
+      at_exit do
+        Process.kill("INT", @pipe.pid)
+        while @ready
+          sleep 1
+        end
+      end
+
+      Thread.new {
+        while( (line = @pipe.gets) )
+          if line =~ /Tunnel remote VM is (.*) (\.\.|at)/
+            @status = $1
+          end
+          if line =~/You may start your tests\./i
+            @ready = true
+          end
+          if line =~ /- (Problem.*)$/
+            @error = $1
+            @quiet = false
+          end
+          if line =~ /== Missing requirements ==/
+            @error = "Missing requirements"
+            @quiet = false
+          end
+          if line =~/Invalid API_KEY provided/
+            @error = "Invalid API_KEY provided"
+            @quiet = false
+          end
+          $stderr.puts line unless @quiet
+        end
+        @ready = false
+        }
     end
 
     def cli_options
@@ -139,7 +133,7 @@ module Sauce
 
       if !@ready
         error_message = "Sauce Connect failed to connect after #{@timeout} seconds"
-        error_message << "\n(Using Sauce Connect at #{@sc4_executable}" if @sc4_executable
+        error_message << "\n(Using Sauce Connect at #{@sc4_executable}"
         raise error_message
       end
     end
@@ -157,24 +151,11 @@ module Sauce
     # Returns true only if the path exists and is executable by the
     # effective current user.
     def find_sauce_connect
-      if @sc4_executable and path_is_connect_executable? @sc4_executable
+      if path_is_connect_executable? @sc4_executable
         File.absolute_path @sc4_executable
       else
-        File.expand_path(File.dirname(__FILE__) + '/../../support/Sauce-Connect.jar')
+        rails TunnelNotPossibleException, Sauce::Connect.plzGetSC4
       end
-    end
-
-    def connect_command
-      command = "#{command_prefix}#{find_sauce_connect}"
-      return command
-    end
-
-    # SC4 doesn't require a prefix
-    def command_prefix
-      unless @sc4_executable
-        return "java -jar "
-      end
-      ""
     end
 
     def path_is_connect_executable? path
@@ -215,18 +196,8 @@ module Sauce
     def array_of_formatted_cli_options_from_hash(hash)
       hash.collect do |key, value|
         opt_name = key.to_s.gsub("_", "-")
-        
-        if !@sc4_executable
-          "--#{opt_name}=#{value}"
-        else
-          "--#{opt_name} #{value}"
-        end
+        return "--#{opt_name} #{value}"
       end
-    end
-
-    def java_is_present?
-      # This is nieve;  Can we be better?
-      system 'java -version'
     end
 
     def self.port_not_open_message
@@ -258,6 +229,17 @@ module Sauce
         
         You can disable network tests by setting :skip_connection_test to true in
         your Sauce.config block.
+      ENDLINE
+    end
+
+    def self.plzGetSC4
+      <<-ENDLINE
+        Using Sauce Connect 3 has been deprecated.  Please set the :sauce_connect_4_executable
+        option in your Sauce.config block to the path of an installation of
+        Sauce Connect 4.
+
+        You can download Sauce Connect 4 for free at
+        http://docs.saucelabs.com/sauce_connect
       ENDLINE
     end
   end

--- a/gems/sauce-connect/sauce-connect.gemspec
+++ b/gems/sauce-connect/sauce-connect.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/sauce/version')
 Gem::Specification.new do |gem|
   gem.name          = "sauce-connect"
-  gem.version       = "#{Sauce::MAJOR_VERSION}.3"
+  gem.version       = "3.6.0"
   gem.authors       = ["R. Tyler Croy", "Steve Hazel", "Dylan Lacey", "Rick Martínez"]
   gem.email         = ["tyler@monkeypox.org"]
   gem.description   = ""

--- a/gems/sauce-connect/sauce-connect.gemspec
+++ b/gems/sauce-connect/sauce-connect.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = ""
   gem.license       = "Apache 2.0"
 
-  gem.files         = Dir['lib/**/*.rb'] + ['support/Sauce-Connect.jar']
+  gem.files         = Dir['lib/**/*.rb']
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]

--- a/gems/sauce-connect/sauce-connect.gemspec
+++ b/gems/sauce-connect/sauce-connect.gemspec
@@ -5,9 +5,9 @@ Gem::Specification.new do |gem|
   gem.version       = "3.6.0"
   gem.authors       = ["R. Tyler Croy", "Steve Hazel", "Dylan Lacey", "Rick Martínez"]
   gem.email         = ["tyler@monkeypox.org"]
-  gem.description   = ""
-  gem.summary       = ""
-  gem.homepage      = ""
+  gem.description   = "A wrapper to start and stop a Sauce Connect tunnel programatically."
+  gem.summary       = "Manage Sauce Connect from within your tests"
+  gem.homepage      = "https://docs.saucelabs.com/reference/sauce-connect"
   gem.license       = "Apache 2.0"
 
   gem.files         = Dir['lib/**/*.rb']
@@ -16,4 +16,15 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency('sauce', "~> #{Sauce::MAJOR_VERSION}")
+
+  gem.post_install_message = <<-ENDLINE
+  To use the Sauce Connect gem, you'll need to download the appropriate
+  Sauce Connect binary from https://docs.saucelabs.com/reference/sauce-connect
+
+  Then, set the 'sauce_connect_4_executable' key in your Sauce.config block, to
+  the path of the unzipped file's /bin/sc.
+  <<ENDLINE
+
+  gem.requirements << 'An account at http://www.saucelabs.com'
+  gem.requirements << 'A working copy of Sauce Connect from https://docs.saucelabs.com/reference/sauce-connect'
 end


### PR DESCRIPTION
Deprecated by Sauce Labs, removing SC3 is a minor version change here because:

A.  We want to keep the major version of all these gems the same
B.  The API of the gem has been added too but not changed
C.  Previous versions don't work anymore anyway.