### PR TITLE
Update webmock helper

### DIFF
--- a/lib/sauce/webmock.rb
+++ b/lib/sauce/webmock.rb
@@ -1,4 +1,4 @@
-require 'webmock/config'
+require 'webmock'
 
 config = WebMock::Config.instance
 


### PR DESCRIPTION
I ran into a NoMethodError at `WebMock.disable_net_connect!`. Inspecting the WebMock object with a debugger, there indeed wasn't a disable_net_connect! method. But when I `require 'webmock'`, WebMock has disable_net_connect!, and all is well.