### PR TITLE
Fix to allow use with Cucumber 2.0

### DIFF
--- a/gems/sauce-cucumber/lib/sauce/cucumber.rb
+++ b/gems/sauce-cucumber/lib/sauce/cucumber.rb
@@ -173,26 +173,25 @@ end
 
 
 begin
-  module Cucumber
-    module Ast
-      class Scenario
-        def sauce_public_link
-          @sauce_public_link ||= ""
-        end
-
-        def sauce_public_link=(link)
-          @sauce_public_link = link
-        end
+  cucumber_ast_module = Cucumber::VERSION >= '2.0.0' ? Cucumber::Core::Ast : Cucumber::Ast
+  cucumber_ast_module.module_exec do
+    class Scenario
+      def sauce_public_link
+        @sauce_public_link ||= ""
       end
 
-      class OutlineTable::ExampleRow
-        def sauce_public_link
-          @sauce_public_link ||= ""
-        end
+      def sauce_public_link=(link)
+        @sauce_public_link = link
+      end
+    end
 
-        def sauce_public_link=(link)
-          @sauce_public_link = link
-        end
+    class OutlineTable::ExampleRow
+      def sauce_public_link
+        @sauce_public_link ||= ""
+      end
+
+      def sauce_public_link=(link)
+        @sauce_public_link = link
       end
     end
   end

--- a/gems/sauce-cucumber/sauce-cucumber.gemspec
+++ b/gems/sauce-cucumber/sauce-cucumber.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('sauce', "~> #{Sauce.version}")
   gem.add_dependency('sauce_whisk', "~>0.0.10")
-  gem.add_dependency('cucumber', ['>= 1.2.0', "<2.0.0"])
+  gem.add_dependency('cucumber', ['>= 1.2.0'])
 end


### PR DESCRIPTION
The `sauce_public_link` getter/setters rely on monkey-patching Cucumber.
However, Cucumber 2.0 was a rewrite and brought a change to the module
hierarchy.

We need to select the correct hierarchy depending on what version of
Cucumber you are running.