### PR TITLE
Return all arguments, not just the first one as a string.

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -192,7 +192,7 @@ module Sauce
     def array_of_formatted_cli_options_from_hash(hash)
       hash.collect do |key, value|
         opt_name = key.to_s.gsub("_", "-")
-        return "--#{opt_name} #{value}"
+        "--#{opt_name} #{value}"
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/saucelabs/sauce_ruby/issues/317