### PR TITLE
Fix uninitialized constant Sauce::RSpec::Spec

### DIFF
--- a/lib/sauce/rspec/rspec_one_support.rb
+++ b/lib/sauce/rspec/rspec_one_support.rb
@@ -3,6 +3,9 @@ require "sauce_whisk"
 
 begin
   require 'spec'
+  # any gem could export a require as 'spec' so we must explicitly check
+  # to see if the expected rspec 1 class has loaded.
+  raise LoadError unless defined?(Spec::Example::ExampleGroup)
   module Sauce
     module RSpec
       class SeleniumExampleGroup < Spec::Example::ExampleGroup
@@ -41,7 +44,7 @@ begin
             @selenium = Sauce::Selenium2.new({:os => os, :browser => browser,
                                               :browser_version => version,
                                               :job_name => description})
-            
+
             begin
               success = super(*args)
               SauceWhisk::Jobs.change_status @selenium.session_id, success


### PR DESCRIPTION
Appium's Ruby test framework is called spec so require 'spec'
will always succed (and cause the uninitialized constant error).

Fix #338