### PR TITLE
Sauce Connect - Quiet and Timeouty.

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -192,7 +192,7 @@ module Sauce
     def array_of_formatted_cli_options_from_hash(hash)
       hash.collect do |key, value|
         opt_name = key.to_s.gsub("_", "-")
-        "--#{opt_name} #{value}"
+        return "--#{opt_name} #{value}"
       end
     end
 

--- a/lib/sauce/utilities/connect.rb
+++ b/lib/sauce/utilities/connect.rb
@@ -1,6 +1,11 @@
 module Sauce
   module Utilities
     class Connect
+      class TunnelNeverStarted < StandardError
+      end
+
+      TIMEOUT = 90 # Magic Numbers!
+
       def self.start_from_config(config)
         self.start(:host => config[:application_host], :port => config[:application_port], :quiet => true)
       end
@@ -13,6 +18,7 @@ module Sauce
           exit(1)
         end
 
+        options[:timeout] = TIMEOUT unless options[:timeout]
         if ParallelTests.first_process?
           unless @tunnel
             @tunnel = Sauce::Connect.new options
@@ -21,9 +27,15 @@ module Sauce
           end
           @tunnel
         else
-          while not File.exist? "sauce_connect.ready"
-            sleep 0.5
+          timeout_after = Time.now + options[:timeout]
+          # Ensure first process has a change to start up
+          sleep 5
+          until (Time.now > timeout_after) || readyfile_found
+            readyfile_found = File.exist? "sauce_connect.ready"
+            sleep 1
           end
+
+          raise(TunnelNeverStarted, "Sauce Connect was not started within #{TIMOUT} seconds") unless readyfile_found
         end
       end
 


### PR DESCRIPTION
Allowed for the @quiet parameter to be passed to Sauce Connect.

Allowed for the timeout before Sauce Connect freaks out to be set as
part of the Sauce Config.

Changed the code when waiting for a tunnel started by ||tests.  Tests
now wait for `Sauce::Utilities::Connect::TIMEOUT` and will raise
`Sauce::Utilities::Connect::TunnelNeverStarted` exceptions unless, uh,
the tunnel starts.

Closes #316 