### PR TITLE
Fix passing options to Sauce Connect

### DIFF
--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -70,7 +70,7 @@ module Sauce
       formatted_cli_options = array_of_formatted_cli_options_from_hash(cli_options)
 
       command_args = ['-u', @config.username, '-k', @config.access_key]
-      command_args << formatted_cli_options
+      command_args += formatted_cli_options
 
       command = "exec #{find_sauce_connect} #{command_args.join(' ')} 2>&1"
 
@@ -192,7 +192,7 @@ module Sauce
     def array_of_formatted_cli_options_from_hash(hash)
       hash.collect do |key, value|
         opt_name = key.to_s.gsub("_", "-")
-        return "--#{opt_name} #{value}"
+        "--#{opt_name} #{value}"
       end
     end
 

--- a/gems/sauce-connect/lib/sauce/connect.rb
+++ b/gems/sauce-connect/lib/sauce/connect.rb
@@ -192,7 +192,7 @@ module Sauce
     def array_of_formatted_cli_options_from_hash(hash)
       hash.collect do |key, value|
         opt_name = key.to_s.gsub("_", "-")
-        "--#{opt_name} #{value}"
+        "--#{opt_name} '#{value}'"
       end
     end
 


### PR DESCRIPTION
Currently when some options are passed to Sauce Connect using
```ruby
Sauce.config do |config|
  config[:connect_options] = { tunnel_identifier: "Tunnel Name" }
end
```
it is simply ignored because only first option (which is always `readyfile`) is return in the first block execution of `collect`.
Additionally I've added some basic escaping for passed parameters using `'` - in my case tunnel name was `LOCAL(username)` and it was simply failing when passed directly to shell as an option.
I wanted to create some spec for that, but didn't have any good idea how to test it.