### PR TITLE
Disable webmock before we reach out to sauce labs

### DIFF
--- a/lib/tasks/parallel_testing.rb
+++ b/lib/tasks/parallel_testing.rb
@@ -72,6 +72,7 @@ namespace :sauce do
 end
 
 def run_parallel_tests(t, args, command)
+  WebMock.disable! if ENV['DISABLE_WEBMOCK'] == 'true'
   if ParallelTests.number_of_running_processes == 0
     username    = ENV["SAUCE_USERNAME"].to_s
     access_key  = ENV["SAUCE_ACCESS_KEY"].to_s


### PR DESCRIPTION
The rake task for running parallel tests is reaching out to sauce labs to find the Limit number of VMs allowed before WebMock.disable! is being called in our env.rb file. This was a work around to allow us to disable WebMock at the task level. 

Is there a better way to go about solving this? If so I am happy to help implement it. I can also update the readme if you are ok with this as a solution.

```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET https://user:key@saucelabs.com/rest/v1/user/limits with headers {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}

You can stub this request with the following snippet:

stub_request(:get, "https://user:key@saucelabs.com/rest/v1/user/limits").
  with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
  to_return(:status => 200, :body => "", :headers => {})

============================================================/usr/local/rvm/gems/ruby-2.1.5/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:114:in `request'
/usr/local/rvm/gems/ruby-2.1.5/gems/rest-client-1.8.0/lib/restclient/request.rb:270:in `net_http_do_request'
/usr/local/rvm/gems/ruby-2.1.5/gems/rest-client-1.8.0/lib/restclient/request.rb:418:in `block in transmit'
/usr/local/rvm/gems/ruby-2.1.5/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:123:in `start_without_connect'
/usr/local/rvm/gems/ruby-2.1.5/gems/webmock-1.21.0/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
/usr/local/rvm/gems/ruby-2.1.5/gems/rest-client-1.8.0/lib/restclient/request.rb:413:in `transmit'
/usr/local/rvm/gems/ruby-2.1.5/gems/rest-client-1.8.0/lib/restclient/request.rb:176:in `execute'
/usr/local/rvm/gems/ruby-2.1.5/gems/rest-client-1.8.0/lib/restclient/request.rb:41:in `execute'
/usr/local/rvm/gems/ruby-2.1.5/gems/rest-client-1.8.0/lib/restclient.rb:65:in `get'
/usr/local/rvm/gems/ruby-2.1.5/gems/sauce-3.5.6/lib/sauce/parallel/test_broker.rb:70:in `concurrency'
/vagrant_data/lib/tasks/parallel_testing.rb:109:in `parse_task_args'
/vagrant_data/lib/tasks/parallel_testing.rb:82:in `run_parallel_tests'
/vagrant_data/lib/tasks/parallel_testing.rb:17:in `block (2 levels) in <top (required)>'
/usr/local/rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `eval'
/usr/local/rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => sauce_new:features
```