### PR TITLE
add sauce job public link on failed rspec3 examples

### DIFF
--- a/lib/sauce/rspec/rspec_formatter.rb
+++ b/lib/sauce/rspec/rspec_formatter.rb
@@ -18,3 +18,31 @@ rescue LoadError
 rescue NameError
   # User is using RSpec 3
 end
+
+begin
+  require 'rspec/core/formatters/exception_presenter'
+  module RSpec
+    module Core
+      module Formatters
+        class ExceptionPresenter
+
+          # add sauce job public link to rspec3 failed examples
+          def fully_formatted(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+            alignment_basis = "#{' ' * @indentation}#{failure_number}) "
+            indentation = ' ' * alignment_basis.length
+            sauce_link = "\n#{indentation}Sauce public job link: #{@example.metadata[:sauce_public_link]}"
+
+            "\n#{alignment_basis}#{description_and_detail(colorizer, indentation)}" \
+            "#{sauce_link}" \
+            "\n#{formatted_message_and_backtrace(colorizer, indentation)}" \
+            "#{extra_detail_formatter.call(failure_number, colorizer, indentation)}"
+          end
+        end
+      end
+    end
+  end
+rescue LoadError
+  # User isn't using RSpec 3
+rescue NameError
+  # User isn't using RSpec 3
+end


### PR DESCRIPTION
I took a look at how rspec2 was adding the sauce public link to failures - and it was overwriting the `dump_failure` method in rspec-core. I decided to take the same approach for rspec3

In rspec3 - the failures are collected in `ExamplesNotification#fully_formatted_failed_examples`
https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/notifications.rb#L110
It goes through every failure and formats the failure message: https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/notifications.rb#L114 so in this PR - I decided to overwrite the `fully_formatted` method.

Couldn't find any test related to this - but I tested it with my own automation test suite - and it worked for rspec2 and rspec3.