### PR TITLE
Set SAUCE_SKIP_PARALLEL_CHECKS to do... that.

### DIFF
--- a/lib/sauce/config.rb
+++ b/lib/sauce/config.rb
@@ -379,7 +379,7 @@ module Sauce
 
         paths.each do |path|
             if File.exist? path
-                Sauce.debug.info "Loading Sauce config from yaml file at #{path}"
+                Sauce.logger.info "Loading Sauce config from yaml file at #{path}"
                 conf = YAML.load_file(path)
                 return conf.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
             end

--- a/lib/tasks/parallel_testing.rb
+++ b/lib/tasks/parallel_testing.rb
@@ -72,7 +72,11 @@ namespace :sauce do
 end
 
 def run_parallel_tests(t, args, command)
-  if ParallelTests.number_of_running_processes == 0
+  skip_check = ENV["SAUCE_SKIP_PARALLEL_CHECKS"]
+  
+  warn_of_skipped_parallel_processes if skip_check
+
+  if((ParallelTests.number_of_running_processes == 0) || skip_check)
     username    = ENV["SAUCE_USERNAME"].to_s
     access_key  = ENV["SAUCE_ACCESS_KEY"].to_s
     if(!username.empty? && !access_key.empty?)
@@ -145,4 +149,16 @@ def parse_task_args(test_tool=:rspec, args)
   return_args.concat files.split
 
   return return_args
+end
+
+def warn_of_skipped_parallel_processes
+  puts <<-ENDLINE
+  ---------------------------------------------------------------------------
+  The SAUCE_SKIP_PARALLEL_CHECKS environment variable is truthy. This will
+  cause the gem to run regardless of other parallel_tests processes running,
+  and may lead to unexpected behaviour including never ending tests.
+
+  Automatic control of Sauce Connect does NOT work with this option.
+  ---------------------------------------------------------------------------
+  ENDLINE
 end


### PR DESCRIPTION
The gem currently checks for other parallel processes when deciding
whether to start or finish Sauce Connect in a specific process.  This
happens because running multiple groups of Parallel tests can cause
endless waiting for other test processes.

Some users control Sauce Connect outside of the gem, and have multiple
tests using parallel_tests at once.  This change allows them to disable
this check.

Bonus patch a logging bug!