### PR TITLE
rescue stopping selenium instance

### DIFF
--- a/lib/sauce/rspec/rspec.rb
+++ b/lib/sauce/rspec/rspec.rb
@@ -168,7 +168,7 @@ begin
                   @selenium.stop
                   Sauce.logger.debug "RSpec - Removing driver for #{Thread.current.object_id} from driver pool."
                   Sauce.driver_pool.delete Thread.current.object_id
-                rescue
+                rescue Exception => e
                   Sauce.logger.error "Error stopping selenium instance"
                   Sauce.logger.error e
                 end

--- a/lib/sauce/rspec/rspec.rb
+++ b/lib/sauce/rspec/rspec.rb
@@ -150,7 +150,6 @@ begin
                 the_test.run
                 success = example.exception.nil?
               ensure
-                @selenium.stop
                 begin
                   os = caps[:os]
                   browser = caps[:browser]
@@ -164,8 +163,15 @@ begin
                   Sauce.logger.error "Error running post job hooks"
                   Sauce.logger.error e
                 end
-                Sauce.logger.debug "RSpec - Removing driver for #{Thread.current.object_id} from driver pool."
-                Sauce.driver_pool.delete Thread.current.object_id
+
+                begin
+                  @selenium.stop
+                  Sauce.logger.debug "RSpec - Removing driver for #{Thread.current.object_id} from driver pool."
+                  Sauce.driver_pool.delete Thread.current.object_id
+                rescue
+                  Sauce.logger.error "Error stopping selenium instance"
+                  Sauce.logger.error e
+                end
               end
               if (exceptions.length > 0)
                 example.instance_variable_set(:@exception, exceptions.first[1])


### PR DESCRIPTION
If `@selenium.stop` throws an error - it'll cause rspec to terminate and potentially cause other `around` hooks to not run. An example of when an error might occur would be if the VM shutdown because the `idle-timeout` is reached. 