### PR TITLE
Add session_id method to driver

### DIFF
--- a/lib/sauce/capybara.rb
+++ b/lib/sauce/capybara.rb
@@ -117,6 +117,10 @@ module Sauce
           @browser
         end
       end
+      
+      def session_id
+        browser.session_id if existing_browser?
+      end
 
       def finish!
         Sauce.logger.debug "Capybara integration called #finish!"


### PR DESCRIPTION
Currently the only way of accessing this is via `driver.browser.session_id`, however this will actually _launch_ a browser if none exists. It would be nice to have a way of getting the session_id without risking launching a new browser.
